### PR TITLE
Update to use new OidcSecurityStorage class

### DIFF
--- a/src/IdentityServerWithIdentitySQLite/Config.cs
+++ b/src/IdentityServerWithIdentitySQLite/Config.cs
@@ -36,8 +36,8 @@ namespace QuickstartIdentityServer
                     ClientName = "9d013e00-91df-487f-b260-c33e77dfb844",
                     ClientId = "9d013e00-91df-487f-b260-c33e77dfb844",
                     AccessTokenType = AccessTokenType.Reference,
-                    AccessTokenLifetime = 15,// 120 seconds, default 60 minutes
-                    IdentityTokenLifetime = 5,
+                    AccessTokenLifetime = 3600,// 120 seconds, default 60 minutes
+                    IdentityTokenLifetime = 300,
                     AllowedGrantTypes = GrantTypes.Implicit,
                     AllowAccessTokensViaBrowser = true,
                     RedirectUris = new List<string>

--- a/src/angular-auth-oidc-client-SSR-test/ClientApp/app/app.module.browser.ts
+++ b/src/angular-auth-oidc-client-SSR-test/ClientApp/app/app.module.browser.ts
@@ -2,16 +2,19 @@ import { NgModule, Inject } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { AppModuleShared } from './app.module.shared';
 import { AppComponent } from './components/app/app.component';
-import { cookieStorageFactory, STORAGE, COOKIES, IStorage } from "./config/storage-config";
-import { OidcSecurityService } from 'angular-auth-oidc-client';
+import { cookieStorageFactory, STORAGE, COOKIES, IStorage, OidcStorageCookies } from "./config/storage-config";
+import { OidcSecurityService, AuthModule } from 'angular-auth-oidc-client';
 import { configAuth } from "./config/auth-config";
+import { CookieStorage } from "cookie-storage";
 
 
 @NgModule({
     bootstrap: [ AppComponent ],
     imports: [
         BrowserModule,
-        AppModuleShared
+        AppModuleShared,
+        AuthModule.forRoot({storage: OidcStorageCookies})
+        // AuthModule.forRoot()
     ],
     providers: [
         { provide: 'ORIGIN_URL', useValue: location.origin },

--- a/src/angular-auth-oidc-client-SSR-test/ClientApp/app/app.module.browser.ts
+++ b/src/angular-auth-oidc-client-SSR-test/ClientApp/app/app.module.browser.ts
@@ -2,7 +2,7 @@ import { NgModule, Inject } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { AppModuleShared } from './app.module.shared';
 import { AppComponent } from './components/app/app.component';
-import { cookieStorageFactory, STORAGE, COOKIES, IStorage, OidcStorageCookies } from "./config/storage-config";
+import { COOKIES, OidcStorageCookies } from "./config/storage-config";
 import { OidcSecurityService, AuthModule } from 'angular-auth-oidc-client';
 import { configAuth } from "./config/auth-config";
 import { CookieStorage } from "cookie-storage";
@@ -14,16 +14,13 @@ import { CookieStorage } from "cookie-storage";
         BrowserModule,
         AppModuleShared,
         AuthModule.forRoot({storage: OidcStorageCookies})
-        // AuthModule.forRoot()
     ],
     providers: [
-        { provide: 'ORIGIN_URL', useValue: location.origin },
-        { provide: STORAGE, useFactory: cookieStorageFactory },
-        { provide: COOKIES, useValue: [document.cookie] }
+        { provide: 'ORIGIN_URL', useValue: location.origin }
     ]
 })
 export class AppModule {
-    constructor(private _oidcSecurityService: OidcSecurityService, @Inject(STORAGE) private _storage: IStorage) {
-        configAuth(_oidcSecurityService, _storage);
+    constructor(private _oidcSecurityService: OidcSecurityService) {
+        configAuth(_oidcSecurityService);
     }
 }

--- a/src/angular-auth-oidc-client-SSR-test/ClientApp/app/app.module.server.ts
+++ b/src/angular-auth-oidc-client-SSR-test/ClientApp/app/app.module.server.ts
@@ -2,8 +2,8 @@ import { NgModule, Inject } from '@angular/core';
 import { ServerModule } from '@angular/platform-server';
 import { AppModuleShared } from './app.module.shared';
 import { AppComponent } from './components/app/app.component';
-import { memoryStorageFactory, STORAGE, COOKIES, IStorage, OidcStorageServer } from "./config/storage-config";
-import { OidcSecurityService, AuthModule } from 'angular-auth-oidc-client';
+import { COOKIES, OidcStorageServer } from "./config/storage-config";
+import { OidcSecurityService, AuthModule, OidcSecurityStorage } from 'angular-auth-oidc-client';
 import { configAuth } from "./config/auth-config";
 
 @NgModule({
@@ -12,13 +12,10 @@ import { configAuth } from "./config/auth-config";
         ServerModule,
         AppModuleShared,
         AuthModule.forRoot({storage: OidcStorageServer})
-    ],
-    providers: [
-        { provide: STORAGE, useFactory: memoryStorageFactory, deps: [COOKIES] }
     ]
 })
 export class AppModule {
-    constructor(private _oidcSecurityService: OidcSecurityService, @Inject(STORAGE) private _storage: IStorage) {
-        configAuth(_oidcSecurityService, _storage);
+    constructor(private _oidcSecurityService: OidcSecurityService) {
+        configAuth(_oidcSecurityService);
     }
 }

--- a/src/angular-auth-oidc-client-SSR-test/ClientApp/app/app.module.server.ts
+++ b/src/angular-auth-oidc-client-SSR-test/ClientApp/app/app.module.server.ts
@@ -2,15 +2,16 @@ import { NgModule, Inject } from '@angular/core';
 import { ServerModule } from '@angular/platform-server';
 import { AppModuleShared } from './app.module.shared';
 import { AppComponent } from './components/app/app.component';
-import { memoryStorageFactory, STORAGE, COOKIES, IStorage } from "./config/storage-config";
-import { OidcSecurityService } from 'angular-auth-oidc-client';
+import { memoryStorageFactory, STORAGE, COOKIES, IStorage, OidcStorageServer } from "./config/storage-config";
+import { OidcSecurityService, AuthModule } from 'angular-auth-oidc-client';
 import { configAuth } from "./config/auth-config";
 
 @NgModule({
     bootstrap: [ AppComponent ],
     imports: [
         ServerModule,
-        AppModuleShared
+        AppModuleShared,
+        AuthModule.forRoot({storage: OidcStorageServer})
     ],
     providers: [
         { provide: STORAGE, useFactory: memoryStorageFactory, deps: [COOKIES] }

--- a/src/angular-auth-oidc-client-SSR-test/ClientApp/app/app.module.shared.ts
+++ b/src/angular-auth-oidc-client-SSR-test/ClientApp/app/app.module.shared.ts
@@ -30,8 +30,7 @@ import { CounterComponent } from './components/counter/counter.component';
             { path: 'counter', component: CounterComponent },
             { path: 'fetch-data', component: FetchDataComponent },
             { path: '**', redirectTo: 'home' }
-        ]),
-        AuthModule.forRoot()
+        ])
     ]
 })
 export class AppModuleShared {

--- a/src/angular-auth-oidc-client-SSR-test/ClientApp/app/components/app/app.component.ts
+++ b/src/angular-auth-oidc-client-SSR-test/ClientApp/app/components/app/app.component.ts
@@ -10,9 +10,4 @@ export class AppComponent {
 
     constructor(private oidcSecurityService: OidcSecurityService) {}
 
-    ngOnInit() {
-        if (typeof location !== "undefined" && window.location.hash) {
-            this.oidcSecurityService.authorizedCallback();
-        }
-    }
 }

--- a/src/angular-auth-oidc-client-SSR-test/ClientApp/app/components/home/home.component.html
+++ b/src/angular-auth-oidc-client-SSR-test/ClientApp/app/components/home/home.component.html
@@ -19,10 +19,14 @@
 
 <p><button (click)="logout()">Log Out!</button></p>
 
-<p>5. Log user info from angular-auth-oidc-client to the console:</p>
+<p>5. Display access token from angular-auth-oidc-client :</p>
 
-<p><button (click)="checkUserInfo()">Check User Info!</button></p>
+<p><button (click)="checkToken()">Update Access Token!</button></p>
 
-<p>5. Log access token from angular-auth-oidc-client to the console:</p>
+<p>{{authToken}}</p>
 
-<p><button (click)="checkToken()">Check Access Token!</button></p>
+<p>6. Display UserInfo from angular-auth-oidc-client:</p>
+
+<p><button (click)="checkUserInfo()">Update User Info!</button></p>
+
+<p>{{userInfo}}</p>

--- a/src/angular-auth-oidc-client-SSR-test/ClientApp/app/components/home/home.component.html
+++ b/src/angular-auth-oidc-client-SSR-test/ClientApp/app/components/home/home.component.html
@@ -3,29 +3,21 @@
 
 <h2>Testing Tools</h2>
 
-<p>1. The button below should set a cookie.</p>
-
-<p><button (click)="SetACookie()">Set a Cookie!</button></p>
-
-<p>2. Below, you should see a printout of the storage object, which should show all the JavaScript accessible cookies. This should work even if you turn JavaScript off (because it will get renered by the server):</p>
-
-<p> {{getStorage()}}</p>
-
-<p>3. Try logging in using angular-auth-oidc-client:</p>
+<p>1. Try logging in using angular-auth-oidc-client:</p>
 
 <p><button (click)="login()">Log In!</button></p>
 
-<p>4. Try logging out using angular-auth-oidc-client:</p>
+<p>2. Try logging out using angular-auth-oidc-client:</p>
 
 <p><button (click)="logout()">Log Out!</button></p>
 
-<p>5. Display access token from angular-auth-oidc-client :</p>
+<p>3. Display access token from angular-auth-oidc-client :</p>
 
 <p><button (click)="checkToken()">Update Access Token!</button></p>
 
 <p>{{authToken}}</p>
 
-<p>6. Display UserInfo from angular-auth-oidc-client:</p>
+<p>4. Display UserInfo from angular-auth-oidc-client:</p>
 
 <p><button (click)="checkUserInfo()">Update User Info!</button></p>
 

--- a/src/angular-auth-oidc-client-SSR-test/ClientApp/app/components/home/home.component.ts
+++ b/src/angular-auth-oidc-client-SSR-test/ClientApp/app/components/home/home.component.ts
@@ -1,5 +1,4 @@
 import { Component, Inject } from '@angular/core';
-import { IStorage, STORAGE, COOKIES } from "../../config/storage-config";
 import * as MemoryStorage from 'memorystorage';
 import { OidcSecurityService} from 'angular-auth-oidc-client';
 
@@ -11,7 +10,7 @@ export class HomeComponent {
     public authToken: string;
     public userInfo: string;
     
-    constructor(@Inject(STORAGE) private _storage: IStorage, private oidcSecurityService: OidcSecurityService) { }
+    constructor(private oidcSecurityService: OidcSecurityService) { }
 
     ngOnInit() {
         if (typeof location !== "undefined" && window.location.hash) {
@@ -22,15 +21,7 @@ export class HomeComponent {
             this.checkUserInfo();
         }, 0);
     }
-
-    getStorage() {
-        return JSON.stringify(this._storage);
-    }
-
-    SetACookie() {
-        this._storage.setItem("firstcookie","ANOTHER VALUE!");
-    }
-
+    
     login() {
         console.log('start login');
         this.oidcSecurityService.authorize();

--- a/src/angular-auth-oidc-client-SSR-test/ClientApp/app/components/home/home.component.ts
+++ b/src/angular-auth-oidc-client-SSR-test/ClientApp/app/components/home/home.component.ts
@@ -8,7 +8,20 @@ import { OidcSecurityService} from 'angular-auth-oidc-client';
     templateUrl: './home.component.html'
 })
 export class HomeComponent {
-    constructor(@Inject(STORAGE) private _storage: IStorage, private oidcSecurityService: OidcSecurityService) {}
+    public authToken: string;
+    public userInfo: string;
+    
+    constructor(@Inject(STORAGE) private _storage: IStorage, private oidcSecurityService: OidcSecurityService) { }
+
+    ngOnInit() {
+        if (typeof location !== "undefined" && window.location.hash) {
+            this.oidcSecurityService.authorizedCallback();
+        }
+        setTimeout(() => {
+            this.checkToken();
+            this.checkUserInfo();
+        }, 0);
+    }
 
     getStorage() {
         return JSON.stringify(this._storage);
@@ -29,10 +42,10 @@ export class HomeComponent {
     }
 
     checkToken() {
-        console.log(this.oidcSecurityService.getToken());
+        this.authToken = JSON.stringify(this.oidcSecurityService.getToken());
     }
     
     checkUserInfo() {
-        console.log(this.oidcSecurityService.getUserData());
+        this.userInfo = JSON.stringify(this.oidcSecurityService.getUserData());
     }
 }

--- a/src/angular-auth-oidc-client-SSR-test/ClientApp/app/config/auth-config.ts
+++ b/src/angular-auth-oidc-client-SSR-test/ClientApp/app/config/auth-config.ts
@@ -15,7 +15,7 @@ export function configAuth(_oidcSecurityService: OidcSecurityService, _storage: 
     config.log_console_warning_active = true;
     config.log_console_debug_active = true;
     config.max_id_token_iat_offset_allowed_in_seconds = 10;
-    config.storage = _storage;
+    // config.storage = _storage;
     //_oidcSecurityService.setStorage(_storage);
     _oidcSecurityService.setupModule(config);
 }

--- a/src/angular-auth-oidc-client-SSR-test/ClientApp/app/config/auth-config.ts
+++ b/src/angular-auth-oidc-client-SSR-test/ClientApp/app/config/auth-config.ts
@@ -1,7 +1,6 @@
 import { OpenIDImplicitFlowConfiguration, OidcSecurityService} from 'angular-auth-oidc-client';
-import { IStorage } from "./storage-config";
 
-export function configAuth(_oidcSecurityService: OidcSecurityService, _storage: IStorage) {
+export function configAuth(_oidcSecurityService: OidcSecurityService) {
     let config = new OpenIDImplicitFlowConfiguration();
     config.stsServer = 'http://localhost:7950';
     config.redirect_url = 'http://localhost:5000';
@@ -15,7 +14,5 @@ export function configAuth(_oidcSecurityService: OidcSecurityService, _storage: 
     config.log_console_warning_active = true;
     config.log_console_debug_active = true;
     config.max_id_token_iat_offset_allowed_in_seconds = 10;
-    // config.storage = _storage;
-    //_oidcSecurityService.setStorage(_storage);
     _oidcSecurityService.setupModule(config);
 }

--- a/src/angular-auth-oidc-client-SSR-test/ClientApp/app/config/storage-config.ts
+++ b/src/angular-auth-oidc-client-SSR-test/ClientApp/app/config/storage-config.ts
@@ -1,6 +1,7 @@
 import { CookieStorage } from 'cookie-storage';
 import * as MemoryStorage from 'memorystorage';
-import { InjectionToken } from "@angular/core";
+import { InjectionToken, Injectable, Inject } from "@angular/core";
+import { OidcSecurityStorage } from 'angular-auth-oidc-client';
 
 export const STORAGE = new InjectionToken<IStorage>('IStorage');
 
@@ -33,4 +34,41 @@ export interface IStorage {
     setItem(key: string, data: string): void;
     [key: string]: any;
     [index: number]: string;
+}
+
+@Injectable()
+export class OidcStorageCookies implements OidcSecurityStorage {
+    private _cookies = new CookieStorage()
+    
+    public read(key: string): any {
+        console.log("about to GET a key!");
+        console.log(key);
+        return JSON.parse(this._cookies.getItem(key));
+    }
+    public write(key: string, value: string): void {
+        console.log("about to set key and value!");
+        console.log(key);
+        console.log(value);
+        this._cookies.setItem(key, JSON.stringify(value));
+    }
+}
+
+@Injectable()
+export class OidcStorageServer implements OidcSecurityStorage {
+    private _dict = new Map<string, any>();
+
+    constructor(@Inject(COOKIES) private _cookies: Array<any>) {
+        _cookies.forEach(element => {
+            if (element instanceof Object && "key" in element && "value" in element) {
+                this._dict.set(element.key, element.value);
+            }
+        });
+    }
+    
+    public read(key: string): any {
+        return JSON.parse(this._dict.get(key));
+    }
+    public write(key: string, value: string): void {
+        this._dict.set(key, JSON.stringify(value));
+    }
 }

--- a/src/angular-auth-oidc-client-SSR-test/ClientApp/app/config/storage-config.ts
+++ b/src/angular-auth-oidc-client-SSR-test/ClientApp/app/config/storage-config.ts
@@ -3,52 +3,19 @@ import * as MemoryStorage from 'memorystorage';
 import { InjectionToken, Injectable, Inject } from "@angular/core";
 import { OidcSecurityStorage } from 'angular-auth-oidc-client';
 
-export const STORAGE = new InjectionToken<IStorage>('IStorage');
-
 export const COOKIES = new InjectionToken('Cookies');
-
-export function cookieStorageFactory() {
-    return new CookieStorage();
-}
-
-export function memoryStorageFactory(COOKIES) {
-    let serverStorage = new MemoryStorage();
-
-    if (COOKIES.constructor === Array) {
-        COOKIES.forEach(element => {
-            if (element instanceof Object && "key" in element && "value" in element) {
-                serverStorage.setItem(element.key, element.value);
-            }
-        });
-    }
-
-    return serverStorage;
-}
-
-export interface IStorage {
-    readonly length: number;
-    clear(): void;
-    getItem(key: string): string | null;
-    key(index: number): string | null;
-    removeItem(key: string): void;
-    setItem(key: string, data: string): void;
-    [key: string]: any;
-    [index: number]: string;
-}
 
 @Injectable()
 export class OidcStorageCookies implements OidcSecurityStorage {
     private _cookies = new CookieStorage()
     
     public read(key: string): any {
-        console.log("about to GET a key!");
-        console.log(key);
-        return JSON.parse(this._cookies.getItem(key));
+        let value = this._cookies.getItem(key);
+        if (value) {
+            return JSON.parse(value);
+        }
     }
     public write(key: string, value: string): void {
-        console.log("about to set key and value!");
-        console.log(key);
-        console.log(value);
         this._cookies.setItem(key, JSON.stringify(value));
     }
 }
@@ -66,7 +33,10 @@ export class OidcStorageServer implements OidcSecurityStorage {
     }
     
     public read(key: string): any {
-        return JSON.parse(this._dict.get(key));
+        let value = this._dict.get(key);
+        if (value) {
+            return JSON.parse(value);
+        }
     }
     public write(key: string, value: string): void {
         this._dict.set(key, JSON.stringify(value));

--- a/src/angular-auth-oidc-client-SSR-test/Views/Home/Index.cshtml
+++ b/src/angular-auth-oidc-client-SSR-test/Views/Home/Index.cshtml
@@ -3,7 +3,7 @@
 }
 
 <app asp-prerender-module="ClientApp/dist/main-server" asp-prerender-data="new { Cookies = ViewContext.HttpContext.Request.Cookies }">Loading...</app>
-<!--<app>Loading...</app>-->
+<!-- <app>Loading...</app> -->
 
 <script src="~/dist/vendor.js" asp-append-version="true"></script>
 @section scripts {


### PR DESCRIPTION
This PR changes the test app to use the new `OidcSecurityStorage` class instead of directly passing a `Storage` implementation. There are two implementations `OidcStorageCookies` (for the browser) and `OidcStorageServer` (for the server).